### PR TITLE
fix: github link in footer

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -33,7 +33,7 @@ social:
   - title: instagram
     url: https://www.instagram.com/hacktoberfestgye
   - title: github
-    url: https://github.com/FunPythonEC/Hacktoberfest-GYE-2024
+    url: https://github.com/Hacktoberfest-GYE/Hacktoberfest-GYE-2024
 
 # Postal address (add as many lines as necessary)
 address:


### PR DESCRIPTION
### Issue: **Replace link for Github [footer]**

- I have updated the GitHub link in the `config.yml` file as per the instructions provided in the issue.

- **Previous Link**: [https://github.com/FunPythonEC/Hacktoberfest-GYE-2024](https://github.com/FunPythonEC/Hacktoberfest-GYE-2024)

- **New Link**: [https://github.com/Hacktoberfest-GYE/Hacktoberfest-GYE-2024](https://github.com/Hacktoberfest-GYE/Hacktoberfest-GYE-2024)
