### PR TITLE
feat: Add /contributors webpage

### DIFF
--- a/src/data/contributors.json
+++ b/src/data/contributors.json
@@ -1,0 +1,52 @@
+[
+  {
+    "login": "bjgavilanes",
+    "avatar_url": "https://avatars.githubusercontent.com/u/116468148?v=4",
+    "html_url": "https://github.com/bjgavilanes"
+  },
+  {
+    "login": "davcortez",
+    "avatar_url": "https://avatars.githubusercontent.com/u/104221111?v=4",
+    "html_url": "https://github.com/davcortez"
+  },
+  {
+    "login": "codediaz",
+    "avatar_url": "https://avatars.githubusercontent.com/u/50778384?v=4",
+    "html_url": "https://github.com/codediaz"
+  },
+  {
+    "login": "jhon-p16",
+    "avatar_url": "https://avatars.githubusercontent.com/u/42450153?v=4",
+    "html_url": "https://github.com/jhon-p16"
+  },
+  {
+    "login": "pintoderian",
+    "avatar_url": "https://avatars.githubusercontent.com/u/31827066?v=4",
+    "html_url": "https://github.com/pintoderian"
+  },
+  {
+    "login": "cpdavila",
+    "avatar_url": "https://avatars.githubusercontent.com/u/25426782?v=4",
+    "html_url": "https://github.com/cpdavila"
+  },
+  {
+    "login": "Veloz-X",
+    "avatar_url": "https://avatars.githubusercontent.com/u/52367350?v=4",
+    "html_url": "https://github.com/Veloz-X"
+  },
+  {
+    "login": "Jorgewlf88",
+    "avatar_url": "https://avatars.githubusercontent.com/u/5809383?v=4",
+    "html_url": "https://github.com/Jorgewlf88"
+  },
+  {
+    "login": "josephinoo",
+    "avatar_url": "https://avatars.githubusercontent.com/u/46098690?v=4",
+    "html_url": "https://github.com/josephinoo"
+  },
+  {
+    "login": "Yeasir-Hossain",
+    "avatar_url": "https://avatars.githubusercontent.com/u/60513610?v=4",
+    "html_url": "https://github.com/Yeasir-Hossain"
+  }
+]

--- a/src/pages/contributors.astro
+++ b/src/pages/contributors.astro
@@ -1,0 +1,39 @@
+---
+import contributors from '../data/contributors.json';
+import Navbar from '../components/Navbar';
+import Layout from '../layouts/Layout.astro';
+---
+
+<Layout
+  title="HacktoberfestGYE - Evento de Código Abierto"
+  description="Conoce a los contributores del Hacktoberfest. Descubre sus perfiles, habilidades y experiencias en nuestra lista de contributores."
+>
+  <header>
+    <Navbar showMenu={false} client:load />
+  </header>
+<section
+  id="contributors"
+  class="container mx-auto px-4 lg:px-0 py-20 md:py-24 lg:py-28"
+>
+  <div class="flex flex-col w-full gap-y-4 items-center mb-16 p-8">
+    <h2 class="text-center text-black font-bold text-2xl lg:text-3xl/[3rem]">
+      ¡Gracias a los contribuidores del Hacktoberfest!
+    </h2>
+  </div>
+  <div class="p-5 grid grid-cols-1 lg:grid-cols-3">
+	    {
+	      contributors.map((contributor) => (
+	        <div class="flex flex-col gap-4 items-center m-5">
+			  <img src={contributor.avatar_url} alt={contributor.login} className="contributor-image" />
+		      <div class="socials flex flex-row gap-4 order-2">
+	          <h3 class="font-bold">{contributor.login}</h3>
+			    <a href={contributor.html_url}>
+					<svg  xmlns="http://www.w3.org/2000/svg"  width="24"  height="24"  viewBox="0 0 24 24"  fill="currentColor"  class="icon icon-tabler icons-tabler-filled icon-tabler-brand-github"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M5.315 2.1c.791 -.113 1.9 .145 3.333 .966l.272 .161l.16 .1l.397 -.083a13.3 13.3 0 0 1 4.59 -.08l.456 .08l.396 .083l.161 -.1c1.385 -.84 2.487 -1.17 3.322 -1.148l.164 .008l.147 .017l.076 .014l.05 .011l.144 .047a1 1 0 0 1 .53 .514a5.2 5.2 0 0 1 .397 2.91l-.047 .267l-.046 .196l.123 .163c.574 .795 .93 1.728 1.03 2.707l.023 .295l.007 .272c0 3.855 -1.659 5.883 -4.644 6.68l-.245 .061l-.132 .029l.014 .161l.008 .157l.004 .365l-.002 .213l-.003 3.834a1 1 0 0 1 -.883 .993l-.117 .007h-6a1 1 0 0 1 -.993 -.883l-.007 -.117v-.734c-1.818 .26 -3.03 -.424 -4.11 -1.878l-.535 -.766c-.28 -.396 -.455 -.579 -.589 -.644l-.048 -.019a1 1 0 0 1 .564 -1.918c.642 .188 1.074 .568 1.57 1.239l.538 .769c.76 1.079 1.36 1.459 2.609 1.191l.001 -.678l-.018 -.168a5.03 5.03 0 0 1 -.021 -.824l.017 -.185l.019 -.12l-.108 -.024c-2.976 -.71 -4.703 -2.573 -4.875 -6.139l-.01 -.31l-.004 -.292a5.6 5.6 0 0 1 .908 -3.051l.152 -.222l.122 -.163l-.045 -.196a5.2 5.2 0 0 1 .145 -2.642l.1 -.282l.106 -.253a1 1 0 0 1 .529 -.514l.144 -.047l.154 -.03z" /></svg>
+				</a>
+		        </div>
+	        </div>
+	      ))
+	    }
+  </div>
+</section>
+</Layout>


### PR DESCRIPTION
First, I built a .json using GitHub API interface through gh-cli. Then, using jq, I filter data important to us.

Finally, I imported data/contributors.json into pages/contributors.astro, similar on how we did with /mentors, /repos, and /speakers.

Think about this, we should abstract this kind of webpage as an astro component. That should be a good PR.