### PR TITLE
feat: coded by community at components/Footer.astro

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -6,6 +6,7 @@
     <div class="flex flex-col md:flex-row justify-center md:justify-between items-center md:items-start gap-8">
       <div class="flex flex-col gap-2 text-sm order-3 md:order-1 text-center md:text-left">
         <span>Copyright © HacktoberfestGYE 2024</span>
+        <span>Desarrollado por <a class="underline decoration-wavy text-muted font-bold decoration-primary" href="/contributors" target="_blank" rel="noopener noreferrer">la comunidad Hacktoberfest</a></span>
       </div>
       <div class="socials flex flex-row gap-4 order-2">
     


### PR DESCRIPTION
As per conversation at #29 , I implement a /contributors webpage -- at #49 --
This PR restores previously erase tag, and restores it as "Coded by community".

Depends on #49 